### PR TITLE
fix(angular-tags-input): Fix the handle key up undefined issue

### DIFF
--- a/projects/angular-tags-input/src/lib/angular-tags-input.component.ts
+++ b/projects/angular-tags-input/src/lib/angular-tags-input.component.ts
@@ -465,7 +465,9 @@ export class AngularTagsInputComponent implements OnInit, AfterViewInit, Control
     }
     // so we have the dropdown shown
     setTimeout(() => {
-      this.dropdown.handleKeyUp($event);
+      if (this.dropdown) {
+        this.dropdown.handleKeyUp($event);
+      }
     }, 10);
   }
 


### PR DESCRIPTION
1:- when select any value from down and press any key after selection it shows handleKeyUp of undefined in console. Fix the issue check the condition if dropdown has some value then handleKeyUp function calls