### PR TITLE
Feat/add html rendering logic in tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This interface defines all configurable options available for the tags input com
 | `displayProperty`        | `string`  | Key in your `tagsData` whose value will be shown as the label for each dropdown option.                                                                         |
 | `showTooltipOnOptions`   | `boolean` | Shows tooltip on hovering the dropdown options. Should be used together with `hoverProperty`.                                                                   |
 | `hoverProperty`          | `string`  | The value that will be displayed as tooltip.                                                                                                                    |
+| `renderTooltipAsHtml`    | `boolean` | When enabled, the tooltip content (`hoverProperty`) is rendered as HTML instead of plain text, so markup such as links is displayed. Defaults to `false`. See the [security consideration](#security-consideration-rendertooltipashtml) below. |
 | `showTagsSelectedInDD`   | `boolean` | Enable it if you want to show a check mark on selected items.                                                                                                   |
 | `hideAddedTags`          | `boolean` | Enable it if you want to hide those tags that have already been selected in dropdown.                                                                           |
 | `placeholder`            | `string`  | The placeholder value for input field.                                                                                                                          |
@@ -96,6 +97,17 @@ If your data is nested, you may need to use these options as well.
 | `nestedTagProperty`     | `string`  | The key in your `tagsData` that have the list of child items.                                                                                              |
 | `nestedTagParentProp`   | `string`  | Speicifies the identifer of parent.                                                                                                                        |
 | `showParentTagsOnly`    | `boolean` | Enable it if you want to show only parent tag if all of its child tags are selected. Disable it if you want to show parent tags along with its child tags. |
+
+### Security consideration (`renderTooltipAsHtml`)
+
+By default the tooltip content is rendered as plain text, so any HTML in your `hoverProperty` value is escaped and shown literally — this is safe regardless of where the data comes from.
+
+When you enable `renderTooltipAsHtml`, the `hoverProperty` value is rendered as **HTML**. Keep the following in mind:
+
+- **Only enable it for trusted content.** Treat the `hoverProperty` value the same way you would treat any HTML you inject into your page. If it can contain user-generated or otherwise untrusted strings, rendering it as HTML opens the door to cross-site scripting (XSS).
+- **Angular sanitizes the markup.** Internally the tooltip uses Angular's `[innerHTML]` binding, which runs the value through Angular's built-in `DomSanitizer` (`SecurityContext.HTML`). This strips dangerous content such as `<script>` tags and inline event handlers (e.g. `onclick`), while keeping safe elements like `<a href>`, `<b>`, `<i>`, etc. The library does **not** call `bypassSecurityTrustHtml`, so this sanitization is always applied.
+- **Sanitization is a safety net, not a guarantee.** It removes the most common attack vectors, but you should still avoid feeding untrusted HTML into the tooltip. Sanitize/validate the data on your side (ideally server-side) before passing it in.
+- **Links open as written.** If your HTML contains anchors, prefer adding `rel="noopener noreferrer"` (and `target="_blank"` where appropriate) so externally-controlled links cannot abuse `window.opener`.
 
 ## Custom Templates
 

--- a/projects/angular-tags-input/src/lib/angular-tags-input.component.ts
+++ b/projects/angular-tags-input/src/lib/angular-tags-input.component.ts
@@ -65,6 +65,7 @@ export class AngularTagsInputComponent implements OnInit, AfterViewInit, Control
     maxItems: null,
     nestedTagParentProp: '',
     keyboardActiveClass: 'angular-tags-dropdown__list__item--active',
+    renderTooltipAsHtml: false,
   };
   onChange: (items: AngularTagItem[]) => void;
   dropdownOverlayPosition = [

--- a/projects/angular-tags-input/src/lib/dropdown/dropdown.component.html
+++ b/projects/angular-tags-input/src/lib/dropdown/dropdown.component.html
@@ -18,7 +18,9 @@
           (click)="onItemClicked(item)"
           tiKeyboardActiveClass="angular-tags-dropdown__list__item--active"
           [isKeyboardActiveItem]="item.tiKeyboardActive"
-          (mouseenter)="showTooltip(item[config.hoverProperty])"
+          cdkOverlayOrigin
+          #onHoverTrigger="cdkOverlayOrigin"
+          (mouseenter)="showTooltip(item[config.hoverProperty], onHoverTrigger)"
           (mouseleave)="hideTooltip()"
         >
           {{ item[config.displayProperty] }}

--- a/projects/angular-tags-input/src/lib/dropdown/dropdown.component.html
+++ b/projects/angular-tags-input/src/lib/dropdown/dropdown.component.html
@@ -34,7 +34,15 @@
   [cdkConnectedOverlayOpen]="inputTooltipShown"
   [cdkConnectedOverlayPositions]="inputTooltipPositions"
 >
-  <div class="tooltip-main" *ngIf="tooltipForInput">
-    {{ tooltipForInput }}
+  <div
+    class="tooltip-main"
+    *ngIf="tooltipForInput"
+    (mouseenter)="onTooltipMouseEnter()"
+    (mouseleave)="onTooltipMouseLeave()"
+  >
+    <ng-container *ngIf="config.renderTooltipAsHtml; else plainTooltip">
+      <span [innerHTML]="tooltipForInput"></span>
+    </ng-container>
+    <ng-template #plainTooltip>{{ tooltipForInput }}</ng-template>
   </div>
 </ng-template>

--- a/projects/angular-tags-input/src/lib/dropdown/dropdown.component.ts
+++ b/projects/angular-tags-input/src/lib/dropdown/dropdown.component.ts
@@ -7,56 +7,58 @@ import {
   Output,
   SimpleChanges,
   TemplateRef,
-  ViewChild
-} from '@angular/core';
-import { ListKeyManager, ListKeyManagerOption } from '@angular/cdk/a11y';
-import { UP_ARROW, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
+  ViewChild,
+} from "@angular/core";
+import { ListKeyManager, ListKeyManagerOption } from "@angular/cdk/a11y";
+import { UP_ARROW, DOWN_ARROW, ENTER } from "@angular/cdk/keycodes";
 import {
   AngularTagItem,
   AngularTagsInputConfig,
-  AngularTagsInputDDFns
-} from '../tags-input-interfaces';
-import { KEY_CODES } from '../constants';
-import { AngularTagsInputService } from '../angular-tags-input.service';
-import { DropdownItemsFilterPipe } from '../dropdown-items-filter.pipe';
-import { CdkOverlayOrigin } from '@angular/cdk/overlay';
+  AngularTagsInputDDFns,
+} from "../tags-input-interfaces";
+import { KEY_CODES } from "../constants";
+import { AngularTagsInputService } from "../angular-tags-input.service";
+import { DropdownItemsFilterPipe } from "../dropdown-items-filter.pipe";
+import { CdkOverlayOrigin } from "@angular/cdk/overlay";
 
 @Component({
-  selector: 'ti-dropdown',
-  templateUrl: './dropdown.component.html',
-  styleUrls: ['./dropdown.component.scss']
+  selector: "ti-dropdown",
+  templateUrl: "./dropdown.component.html",
+  styleUrls: ["./dropdown.component.scss"],
 })
 export class DropdownComponent
-  implements OnInit, AngularTagsInputDDFns, OnChanges {
+  implements OnInit, AngularTagsInputDDFns, OnChanges
+{
   @Input() config: AngularTagsInputConfig;
   @Input() listItems: AngularTagItem[] = [];
-  @Input() inputVal = '';
+  @Input() inputVal = "";
   @Input() dropDownTemplate: TemplateRef<any>;
   @Input() tagsLoading: boolean;
   @Input() keyPress: any;
   @Output() itemAdded = new EventEmitter<AngularTagItem>();
   @Output() itemClicked = new EventEmitter<AngularTagItem>();
-  @ViewChild('defaultTagOptionTemplate', { static: true })
+  @ViewChild("defaultTagOptionTemplate", { static: true })
   defaultTagOptionTemplate: TemplateRef<any>;
 
   dropdownItemsFilter = new DropdownItemsFilterPipe();
   ddIdPrefix: string;
   context: any;
   activeIndex: number;
-  identifierSeparator = '__';
+  identifierSeparator = "__";
   keyboardEventsManager: ListKeyManager<ListKeyManagerOption>;
   itemsMap: Map<string, any> = new Map<string, any>();
   tooltipForInput: string;
   inputTooltipOverlayOrigin: CdkOverlayOrigin;
   tooltipTimeout: number;
+  tooltipHideTimeout: number;
   inputTooltipShown: boolean;
   inputTooltipPositions = [
-    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
-    { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom' },
-    { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'bottom' },
-    { originX: 'end', originY: 'top', overlayX: 'end', overlayY: 'bottom' },
+    { originX: "start", originY: "bottom", overlayX: "start", overlayY: "top" },
+    { originX: "start", originY: "top", overlayX: "start", overlayY: "bottom" },
+    { originX: "end", originY: "bottom", overlayX: "end", overlayY: "bottom" },
+    { originX: "end", originY: "top", overlayX: "end", overlayY: "bottom" },
   ];
-  constructor(private readonly tagsInputService: AngularTagsInputService) { }
+  constructor(private readonly tagsInputService: AngularTagsInputService) {}
 
   ngOnInit() {
     if (!this.dropDownTemplate) {
@@ -70,15 +72,15 @@ export class DropdownComponent
       fns: {
         onItemClicked: this.onItemClicked.bind(this),
         showTooltip: this.showTooltip.bind(this),
-        hideTooltip: this.hideTooltip.bind(this)
-      }
+        hideTooltip: this.hideTooltip.bind(this),
+      },
     };
     this.keyboardEventsManager = new ListKeyManager([
-      ...(this.listItems as any)
+      ...(this.listItems as any),
     ]);
     this.populateItemsMap(this.listItems);
     this.ddIdPrefix = this.getRandomString();
-    this.tagsInputService.log(this.itemsMap, 'items populated initially');
+    this.tagsInputService.log(this.itemsMap, "items populated initially");
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -86,7 +88,7 @@ export class DropdownComponent
       // if the list items change, update the context items (because they're not automatically updated)
       this.filterItems(this.inputVal, changes.listItems.currentValue);
       this.populateItemsMap(
-        changes.listItems ? changes.listItems.currentValue : this.listItems
+        changes.listItems ? changes.listItems.currentValue : this.listItems,
       );
     }
 
@@ -94,7 +96,7 @@ export class DropdownComponent
       // if the list items change, update the context items (because they're not automatically updated)
       this.filterItems(changes.inputVal.currentValue);
       this.populateItemsMap(
-        changes.listItems ? changes.listItems.currentValue : this.listItems
+        changes.listItems ? changes.listItems.currentValue : this.listItems,
       );
     }
   }
@@ -107,7 +109,7 @@ export class DropdownComponent
 
   filterItems(searchTerm = this.inputVal, items = this.listItems) {
     this.context.items = [
-      ...this.dropdownItemsFilter.transform(items, this.config, searchTerm)
+      ...this.dropdownItemsFilter.transform(items, this.config, searchTerm),
     ];
     this.ddIdPrefix = this.getRandomString();
   }
@@ -121,7 +123,7 @@ export class DropdownComponent
 
   populateItemsMap(items, prefix = null) {
     if (prefix === null) {
-      prefix = '';
+      prefix = "";
     } else {
       prefix += this.identifierSeparator;
     }
@@ -162,9 +164,9 @@ export class DropdownComponent
     if (isKeyDown || isKeyUp) {
       // passing the event to key manager so we get a change fired
       this.setActiveElement(event);
-    } else if (isKeyEnter && (this.keyboardEventsManager.activeItem != null)) {
+    } else if (isKeyEnter && this.keyboardEventsManager.activeItem != null) {
       this.itemClicked.emit(
-        this.keyboardEventsManager.activeItem as AngularTagItem
+        this.keyboardEventsManager.activeItem as AngularTagItem,
       );
     }
   }
@@ -185,7 +187,7 @@ export class DropdownComponent
     const isKeyDown = this.isKeyDown(event);
     const isKeyUp = this.isKeyUp(event);
     const previousActiveItem = {
-      ...this.keyboardEventsManager.activeItem
+      ...this.keyboardEventsManager.activeItem,
     } as AngularTagItem;
     if (isKeyDown) {
       this.setNextActiveElement(previousActiveItem, this.listItems);
@@ -208,22 +210,22 @@ export class DropdownComponent
     keyIdentifier =
       keyIdentifierArr.length > 1
         ? [...keyIdentifierArr]
-          .splice(0, keyIdentifierArr.length - 1)
-          .join(this.identifierSeparator)
+            .splice(0, keyIdentifierArr.length - 1)
+            .join(this.identifierSeparator)
         : keyIdentifierArr[0];
     treeItems = Object.keys(this.itemsMap).filter((key) =>
-      new RegExp(`^${keyIdentifier}${this.identifierSeparator}`).test(key)
+      new RegExp(`^${keyIdentifier}${this.identifierSeparator}`).test(key),
     );
     if (!treeItems.length) {
       treeItems = Object.keys(this.itemsMap).filter((key) =>
-        new RegExp(`^${keyIdentifier}$`).test(key)
+        new RegExp(`^${keyIdentifier}$`).test(key),
       );
     }
     index = treeItems.findIndex((id) => id === identifier);
     if (index === treeItems.length - 1) {
       this.setActiveElementRecursively(
         this.findNextParent(keyIdentifierArr),
-        this.listItems
+        this.listItems,
       );
     } else {
       this.setActiveElementRecursively(treeItems[index + 1], this.listItems);
@@ -242,18 +244,18 @@ export class DropdownComponent
     }
     const nextIdArr = [...keyIdentifierArr].splice(
       0,
-      keyIdentifierArr.length - 1
+      keyIdentifierArr.length - 1,
     );
     nextIdArr[nextIdArr.length - 1] = `${+nextIdArr[nextIdArr.length - 1] + 1}`;
     keyIdentifier = nextIdArr.join(this.identifierSeparator);
     treeItems = Object.keys(this.itemsMap).filter((key) =>
-      new RegExp(`^${keyIdentifier}`).test(key)
+      new RegExp(`^${keyIdentifier}`).test(key),
     );
     if (treeItems.length) {
       return treeItems[0];
     } else {
       return this.findNextParent([
-        ...keyIdentifierArr.splice(0, keyIdentifierArr.length - 1)
+        ...keyIdentifierArr.splice(0, keyIdentifierArr.length - 1),
       ]);
     }
   }
@@ -273,22 +275,22 @@ export class DropdownComponent
     keyIdentifier =
       keyIdentifierArr.length > 1
         ? [...keyIdentifierArr]
-          .splice(0, keyIdentifierArr.length - 1)
-          .join(this.identifierSeparator)
+            .splice(0, keyIdentifierArr.length - 1)
+            .join(this.identifierSeparator)
         : keyIdentifierArr[0];
     treeItems = Object.keys(this.itemsMap).filter((key) =>
-      new RegExp(`^${keyIdentifier}(${this.identifierSeparator})?`).test(key)
+      new RegExp(`^${keyIdentifier}(${this.identifierSeparator})?`).test(key),
     );
     if (!treeItems.length) {
       treeItems = Object.keys(this.itemsMap).filter((key) =>
-        new RegExp(`^${keyIdentifier}$`).test(key)
+        new RegExp(`^${keyIdentifier}$`).test(key),
       );
     }
     index = treeItems.findIndex((id) => id === identifier);
     if (treeItems.length === 1 || index === 0) {
       this.setActiveElementRecursively(
         this.findPrevousParentLastChild(keyIdentifierArr, identifier),
-        this.listItems
+        this.listItems,
       );
     } else {
       this.setActiveElementRecursively(treeItems[index - 1], this.listItems);
@@ -306,11 +308,11 @@ export class DropdownComponent
       : prevIdArr[prevIdArr.length - 1];
     keyIdentifier = prevIdArr.join(this.identifierSeparator);
     let treeItems = Object.keys(this.itemsMap).filter((key) =>
-      new RegExp(`^${keyIdentifier}${this.identifierSeparator}`).test(key)
+      new RegExp(`^${keyIdentifier}${this.identifierSeparator}`).test(key),
     );
     if (treeItems.length === 0) {
       treeItems = Object.keys(this.itemsMap).filter((key) =>
-        new RegExp(`^${keyIdentifier}$`).test(key)
+        new RegExp(`^${keyIdentifier}$`).test(key),
       );
     }
     if (treeItems.length > 0) {
@@ -321,7 +323,7 @@ export class DropdownComponent
     } else if (keyIdentifierArr.length > 1) {
       return this.findPrevousParentLastChild(
         [...keyIdentifierArr.splice(0, keyIdentifierArr.length - 1)],
-        prevItemIdentifier
+        prevItemIdentifier,
       );
     } else {
       keyIdentifier = keyIdentifierArr.join(this.identifierSeparator);
@@ -333,7 +335,7 @@ export class DropdownComponent
     for (let i = 0, len = items.length; i < len; ++i) {
       items[i].tiKeyboardActive = false;
       if (items[i].tiIdentifier === identifier) {
-        this.keyboardEventsManager = new ListKeyManager([...(items)]);
+        this.keyboardEventsManager = new ListKeyManager([...items]);
         items[i].tiKeyboardActive = true; // select next item
         this.keyboardEventsManager.setActiveItem(items[i]);
       }
@@ -343,7 +345,7 @@ export class DropdownComponent
       ) {
         this.setActiveElementRecursively(
           identifier,
-          items[i][this.config.nestedTagProperty]
+          items[i][this.config.nestedTagProperty],
         );
       }
     }
@@ -365,6 +367,22 @@ export class DropdownComponent
       return;
     }
     clearTimeout(this.tooltipTimeout);
-    this.inputTooltipShown = false;
+    if (this.config.renderTooltipAsHtml) {
+      // give the pointer time to travel onto the tooltip to click links inside it
+      this.tooltipHideTimeout = setTimeout(() => {
+        this.inputTooltipShown = false;
+      }, 200) as unknown as number;
+    } else {
+      this.inputTooltipShown = false;
+    }
+  }
+
+  onTooltipMouseEnter() {
+    // pointer entered the tooltip — cancel the pending hide so it stays open
+    clearTimeout(this.tooltipHideTimeout);
+  }
+
+  onTooltipMouseLeave() {
+    this.hideTooltip();
   }
 }

--- a/projects/angular-tags-input/src/lib/dropdown/dropdown.component.ts
+++ b/projects/angular-tags-input/src/lib/dropdown/dropdown.component.ts
@@ -371,7 +371,7 @@ export class DropdownComponent
       // give the pointer time to travel onto the tooltip to click links inside it
       this.tooltipHideTimeout = setTimeout(() => {
         this.inputTooltipShown = false;
-      }, 0) as unknown as number;
+      }, 200) as unknown as number;
     } else {
       this.inputTooltipShown = false;
     }

--- a/projects/angular-tags-input/src/lib/dropdown/dropdown.component.ts
+++ b/projects/angular-tags-input/src/lib/dropdown/dropdown.component.ts
@@ -371,7 +371,7 @@ export class DropdownComponent
       // give the pointer time to travel onto the tooltip to click links inside it
       this.tooltipHideTimeout = setTimeout(() => {
         this.inputTooltipShown = false;
-      }, 200) as unknown as number;
+      }, 0) as unknown as number;
     } else {
       this.inputTooltipShown = false;
     }

--- a/projects/angular-tags-input/src/lib/tags-input-interfaces.ts
+++ b/projects/angular-tags-input/src/lib/tags-input-interfaces.ts
@@ -1,6 +1,7 @@
 export interface AngularTagsInputConfig {
   defaultClass?: string;
   showTooltipOnOptions?: boolean;
+  renderTooltipAsHtml?: boolean;
   ddHasBackdrop?: boolean;
   keyboardActiveClass?: string;
   additionalClasses?: string;

--- a/projects/tags-input-demo/src/app/app.component.html
+++ b/projects/tags-input-demo/src/app/app.component.html
@@ -375,6 +375,9 @@
     <input type="checkbox" name="show-tooltip-on-options" [checked]="simpleTagsInputConfig2.showTooltipOnOptions" (change)="changeConfigOption($event, 'showTooltipOnOptions')">
     <label for="show-tooltip-on-options">Show tooltip on Options</label> &nbsp; &nbsp;
 
+    <input type="checkbox" name="render-tooltip-as-html" [checked]="simpleTagsInputConfig2.renderTooltipAsHtml" (change)="changeConfigOption($event, 'renderTooltipAsHtml')">
+    <label for="render-tooltip-as-html">Render tooltip as HTML</label> &nbsp; &nbsp;
+
     <input type="checkbox" name="tags added" [checked]="simpleTagsInputConfig2.hideAddedTags" (change)="changeConfigOption($event, 'hideAddedTags')">
     <label for="tags added">Hide items</label> &nbsp; &nbsp;
 

--- a/projects/tags-input-demo/src/app/app.component.ts
+++ b/projects/tags-input-demo/src/app/app.component.ts
@@ -96,6 +96,7 @@ export class AppComponent {
     hideTags: false,
     ddHasBackdrop: true,
     showTooltipOnOptions: true,
+    renderTooltipAsHtml: true,
     hideDDOnTagSelect: true,
   };
 

--- a/projects/tags-input-demo/src/app/data.ts
+++ b/projects/tags-input-demo/src/app/data.ts
@@ -106,12 +106,12 @@ export const TAGS_DATA_SIMPLE = [
   {
     Id: 259,
     full_name: 'Devil',
-    description: 'Tempore consequatur vitae iusto explicabo adipisci mollitia amet porro incidunt.',
+    description: 'asd <a href="https://dev.icplan.com/#/auth/forgot-password" target="_blank" rel="noopener noreferrer" class="channel-description-link" title="https://dev.icplan.com/#/auth/forgot-password">dev.icplan.com/#/auth/forgot-password</a>',
   },
   {
     Id: 253,
     full_name: 'Dexter\'s Lab',
-    description: 'Tempore consequatur',
+    description: 'Read the docs at <a href="https://github.com/Ahsanayaz/angular-tags-input" target="_blank" rel="noopener noreferrer" class="channel-description-link" title="angular-tags-input on GitHub">github.com/Ahsanayaz/angular-tags-input</a>',
   },
 ];
 


### PR DESCRIPTION
**Feature: Added Rendering of HTML content inside Tooltips and make the tooltips hoverable**

 Added a config for configuring how the content inside the tooltip being shown, i.e plain text or as HTML.
 
 ### Why need for this Feature
In ICplan we have a requirement that the Channel Description's(tooltip content) can contain hyperlinks
<img width="1884" height="948" alt="image" src="https://github.com/user-attachments/assets/67a00088-177b-4831-b324-e05b5342df9e" />

 